### PR TITLE
Add POST_BUILD_COPY_EXT_LIBS option in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,12 +5,14 @@ set(ARCH "x64" CACHE STRING "Arch")
 
 option(BUILD_SHARED "Option to build shared library" ON)
 option(BUILD_STATIC "Option to build static library" ON)
+option(POST_BUILD_COPY_EXT_LIBS "Option to copy external libraries to build directory" ON)
 
 message(STATUS "PLATFORM: ${PLATFORM}")
 message(STATUS "ARCH: ${ARCH}")
 
 message(STATUS "BUILD_SHARED: ${BUILD_SHARED}")
 message(STATUS "BUILD_STATIC: ${BUILD_STATIC}")
+message(STATUS "POST_BUILD_COPY_EXT_LIBS: ${POST_BUILD_COPY_EXT_LIBS}")
 
 if(PLATFORM STREQUAL "macos")
    set(CMAKE_OSX_DEPLOYMENT_TARGET 14.0)
@@ -147,19 +149,21 @@ if(BUILD_SHARED)
 
       target_link_libraries(altsound_test PUBLIC altsound_shared)
 
-      if(PLATFORM STREQUAL "win")
-         add_custom_command(TARGET altsound_test POST_BUILD
-            COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/third-party/build-libs/${PLATFORM}/${ARCH}/bass.lib" "$<TARGET_FILE_DIR:altsound_test>"
-            COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/third-party/runtime-libs/${PLATFORM}/${ARCH}/bass.dll" "$<TARGET_FILE_DIR:altsound_test>"
-         )
-      elseif(PLATFORM STREQUAL "macos")
-         add_custom_command(TARGET altsound_test POST_BUILD
-            COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/third-party/runtime-libs/${PLATFORM}/${ARCH}/libbass.dylib" "$<TARGET_FILE_DIR:altsound_test>"
-         )
-      elseif(PLATFORM STREQUAL "linux")
-         add_custom_command(TARGET altsound_test POST_BUILD
-            COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/third-party/runtime-libs/${PLATFORM}/${ARCH}/libbass.so" "$<TARGET_FILE_DIR:altsound_test>"
-         )
+      if(POST_BUILD_COPY_EXT_LIBS)
+         if(PLATFORM STREQUAL "win")
+            add_custom_command(TARGET altsound_test POST_BUILD
+               COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/third-party/build-libs/${PLATFORM}/${ARCH}/bass.lib" "$<TARGET_FILE_DIR:altsound_test>"
+               COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/third-party/runtime-libs/${PLATFORM}/${ARCH}/bass.dll" "$<TARGET_FILE_DIR:altsound_test>"
+            )
+         elseif(PLATFORM STREQUAL "macos")
+            add_custom_command(TARGET altsound_test POST_BUILD
+               COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/third-party/runtime-libs/${PLATFORM}/${ARCH}/libbass.dylib" "$<TARGET_FILE_DIR:altsound_test>"
+            )
+         elseif(PLATFORM STREQUAL "linux")
+            add_custom_command(TARGET altsound_test POST_BUILD
+               COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/third-party/runtime-libs/${PLATFORM}/${ARCH}/libbass.so" "$<TARGET_FILE_DIR:altsound_test>"
+            )
+         endif()
       endif()
    endif()
 endif()
@@ -202,19 +206,21 @@ if(BUILD_STATIC)
          target_link_libraries(altsound_test_s PUBLIC altsound_static bass)
       endif()
 
-      if(PLATFORM STREQUAL "win")
-         add_custom_command(TARGET altsound_test_s POST_BUILD
-            COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/third-party/build-libs/${PLATFORM}/${ARCH}/bass.lib" "$<TARGET_FILE_DIR:altsound_test_s>"
-            COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/third-party/runtime-libs/${PLATFORM}/${ARCH}/bass.dll" "$<TARGET_FILE_DIR:altsound_test_s>"
-         )
-      elseif(PLATFORM STREQUAL "macos")
-         add_custom_command(TARGET altsound_test_s POST_BUILD
-            COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/third-party/runtime-libs/${PLATFORM}/${ARCH}/libbass.dylib" "$<TARGET_FILE_DIR:altsound_test_s>"
-         )
-      elseif(PLATFORM STREQUAL "linux")
-         add_custom_command(TARGET altsound_test_s POST_BUILD
-            COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/third-party/runtime-libs/${PLATFORM}/${ARCH}/libbass.so" "$<TARGET_FILE_DIR:altsound_test_s>"
-         )
+      if(POST_BUILD_COPY_EXT_LIBS)
+         if(PLATFORM STREQUAL "win")
+            add_custom_command(TARGET altsound_test_s POST_BUILD
+               COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/third-party/build-libs/${PLATFORM}/${ARCH}/bass.lib" "$<TARGET_FILE_DIR:altsound_test_s>"
+               COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/third-party/runtime-libs/${PLATFORM}/${ARCH}/bass.dll" "$<TARGET_FILE_DIR:altsound_test_s>"
+            )
+         elseif(PLATFORM STREQUAL "macos")
+            add_custom_command(TARGET altsound_test_s POST_BUILD
+               COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/third-party/runtime-libs/${PLATFORM}/${ARCH}/libbass.dylib" "$<TARGET_FILE_DIR:altsound_test_s>"
+            )
+         elseif(PLATFORM STREQUAL "linux")
+            add_custom_command(TARGET altsound_test_s POST_BUILD
+               COMMAND "${CMAKE_COMMAND}" -E copy "${CMAKE_SOURCE_DIR}/third-party/runtime-libs/${PLATFORM}/${ARCH}/libbass.so" "$<TARGET_FILE_DIR:altsound_test_s>"
+            )
+         endif()
       endif()
    endif()
 endif()


### PR DESCRIPTION
Hi!
I'm in the process of creating Arch Linux AUR packages of all the libraries necessary to build & use vpinball and noticed that I can't turn off the copy of the external libraries in this project.
I don't use your external.sh build script, because I installed libbass.so right into my system with the existing AUR package and want to link it dynamically.

This is my first pull request - I hope it's okay :) 
Any feedback is welcome!

Before:
```
(base) [joni@linuxjoni04 libaltsound]$ cmake -DPLATFORM=linux -DARCH=x64 -DCMAKE_BUILD_TYPE=Release -DBUILD_STATIC=FALSE -DCMAKE_BUILD_WITH_INSTALL_RPATH=FALSE  -B build
-- PLATFORM: linux
-- ARCH: x64
-- BUILD_SHARED: ON
-- BUILD_STATIC: FALSE
-- POST_BUILD_COPY_EXT_LIBS: ON
-- The C compiler identification is GNU 15.1.1
-- The CXX compiler identification is GNU 15.1.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done (0.3s)
-- Generating done (0.0s)
-- Build files have been written to: /home/joni/git/libaltsound/build
(base) [joni@linuxjoni04 libaltsound]$ cmake --build build -- -j$(nproc)
[  7%] Building CXX object CMakeFiles/altsound_shared.dir/src/altsound_data.cpp.o
[ 15%] Building CXX object CMakeFiles/altsound_shared.dir/src/altsound_file_parser.cpp.o
[ 23%] Building CXX object CMakeFiles/altsound_shared.dir/src/gsound_processor.cpp.o
[ 30%] Building CXX object CMakeFiles/altsound_shared.dir/src/altsound.cpp.o
[ 38%] Building CXX object CMakeFiles/altsound_shared.dir/src/altsound_logger.cpp.o
[ 46%] Building CXX object CMakeFiles/altsound_shared.dir/src/gsound_csv_parser.cpp.o
[ 53%] Building CXX object CMakeFiles/altsound_shared.dir/src/altsound_processor.cpp.o
[ 61%] Building CXX object CMakeFiles/altsound_shared.dir/src/altsound_ini_processor.cpp.o
[ 69%] Building CXX object CMakeFiles/altsound_shared.dir/src/altsound_processor_base.cpp.o
[ 76%] Building CXX object CMakeFiles/altsound_shared.dir/src/altsound_csv_parser.cpp.o
[ 84%] Linking CXX shared library libaltsound.so
[ 84%] Built target altsound_shared
[ 92%] Building CXX object CMakeFiles/altsound_test.dir/src/test.cpp.o
[100%] Linking CXX executable altsound_test
Error copying file "/home/joni/git/libaltsound/third-party/runtime-libs/linux/x64/libbass.so" to "/home/joni/git/libaltsound/build".
make[2]: *** [CMakeFiles/altsound_test.dir/build.make:103: altsound_test] Error 1
make[2]: *** Deleting file 'altsound_test'
make[1]: *** [CMakeFiles/Makefile2:122: CMakeFiles/altsound_test.dir/all] Error 2
make: *** [Makefile:136: all] Error 2
```

After:
```
(base) [joni@linuxjoni04 libaltsound]$ cmake -DPLATFORM=linux -DARCH=x64 -DCMAKE_BUILD_TYPE=Release -DBUILD_STATIC=FALSE -DCMAKE_BUILD_WITH_INSTALL_RPATH=FALSE -DPOST_BUILD_COPY_EXT_LIBS=FALSE -B build
-- PLATFORM: linux
-- ARCH: x64
-- BUILD_SHARED: ON
-- BUILD_STATIC: FALSE
-- POST_BUILD_COPY_EXT_LIBS: FALSE
-- The C compiler identification is GNU 15.1.1
-- The CXX compiler identification is GNU 15.1.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done (0.2s)
-- Generating done (0.0s)
-- Build files have been written to: /home/joni/git/libaltsound/build
(base) [joni@linuxjoni04 libaltsound]$ cmake --build build -- -j$(nproc)
[  7%] Building CXX object CMakeFiles/altsound_shared.dir/src/altsound_logger.cpp.o
[ 23%] Building CXX object CMakeFiles/altsound_shared.dir/src/altsound_file_parser.cpp.o
[ 23%] Building CXX object CMakeFiles/altsound_shared.dir/src/altsound_csv_parser.cpp.o
[ 30%] Building CXX object CMakeFiles/altsound_shared.dir/src/gsound_processor.cpp.o
[ 38%] Building CXX object CMakeFiles/altsound_shared.dir/src/altsound.cpp.o
[ 53%] Building CXX object CMakeFiles/altsound_shared.dir/src/gsound_csv_parser.cpp.o
[ 53%] Building CXX object CMakeFiles/altsound_shared.dir/src/altsound_data.cpp.o
[ 61%] Building CXX object CMakeFiles/altsound_shared.dir/src/altsound_ini_processor.cpp.o
[ 69%] Building CXX object CMakeFiles/altsound_shared.dir/src/altsound_processor_base.cpp.o
[ 76%] Building CXX object CMakeFiles/altsound_shared.dir/src/altsound_processor.cpp.o
[ 84%] Linking CXX shared library libaltsound.so
[ 84%] Built target altsound_shared
[ 92%] Building CXX object CMakeFiles/altsound_test.dir/src/test.cpp.o
[100%] Linking CXX executable altsound_test
[100%] Built target altsound_test
```